### PR TITLE
more closely match c xattr methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 node-xattr is a native module wrapping xattr to read and set extended attributes on files. 
 
-## Install
-
-npm install xattr
-
 ## Build
 
 node-waf configure && node-waf build && node-waf install
@@ -16,11 +12,19 @@ node-waf configure && node-waf build && node-waf install
 
 Get all the extended attributes on a file, returns obj 
  
+  var attrs = xattr.glist("/path/to/file");
+
+Get just the extended attribute names on a file, returns obj 
+ 
   var attrs = xattr.list("/path/to/file");
 
 Set an extended attribute on a file.  Note at thie moment you can only set string values.
   
   xattr.set("/path/to/file", "someAttribute", "someValue");
+
+Remove xattr on a file, returns bool
+ 
+  xattr.remove("/path/to/file", "user.attribute");
 
 
  

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Get all the extended attributes on a file, returns obj
  
   var attrs = xattr.glist("/path/to/file");
 
-Get just the extended attribute names on a file, returns obj 
+Get just the extended attribute names on a file, returns array obj 
  
   var attrs = xattr.list("/path/to/file");
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 node-xattr is a native module wrapping xattr to read and set extended attributes on files. 
 
-## Install
-
-npm install xattr
-
 ## Build
 
 node-waf configure && node-waf build && node-waf install
@@ -16,11 +12,19 @@ node-waf configure && node-waf build && node-waf install
 
 Get all the extended attributes on a file, returns obj 
  
+  var attrs = xattr.glist("/path/to/file");
+
+Get just the extended attribute names on a file, returns array obj 
+ 
   var attrs = xattr.list("/path/to/file");
 
 Set an extended attribute on a file.  Note at thie moment you can only set string values.
   
   xattr.set("/path/to/file", "someAttribute", "someValue");
+
+Remove xattr on a file, returns bool
+ 
+  xattr.remove("/path/to/file", "user.attribute");
 
 
  

--- a/src/node_xattr.cc
+++ b/src/node_xattr.cc
@@ -40,8 +40,8 @@ using namespace std;
         return ThrowException(Exception::TypeError(             \
                 String::New("Argument must be a string")));     \
     String::AsciiValue VAR(args[I]);
-
-
+//toggle strict compatibility with c api
+bool compat = false;
 
 string ObjectToString(Local<Value> value) {
     String::AsciiValue ascii_value(value);
@@ -138,7 +138,7 @@ static Handle<Value> get(const Arguments& args) {
 	return result;
 }
 
-static Handle<Value> list(const Arguments& args) {
+static Handle<Value> clist(const Arguments& args) {
 	HandleScope scope;
 	char list[XATTR_SIZE];
 	const char *filename;
@@ -190,17 +190,33 @@ static Handle<Value> remove(const Arguments& args) {
         return Boolean::New(true);
 }
 
+static Handle<Value> list(const Arguments& args){
+if(compat)
+	return(clist(args));
+else
+	return(glist(args));
+}
 
+
+
+static Handle<Value> ccompat(const Arguments& args){
+ HandleScope scope;
+ if(args[0]->IsBoolean())
+	 compat = args[0]->ToBoolean()->Value();
+ return(Boolean::New(compat));
+}
 
 extern "C" {
 
 	void init (Handle<Object> target)
 	{
 		NODE_SET_METHOD(target, "list",  list);
+		NODE_SET_METHOD(target, "clist", clist);
 		NODE_SET_METHOD(target, "glist", glist);
 		NODE_SET_METHOD(target, "set", set);
 		NODE_SET_METHOD(target, "get", get);
 		NODE_SET_METHOD(target, "remove", remove);
+		NODE_SET_METHOD(target, "ccompat", ccompat);
 	}
 
 	NODE_MODULE(xattr, init);

--- a/src/node_xattr.cc
+++ b/src/node_xattr.cc
@@ -74,7 +74,7 @@ static Handle<Value> set(const Arguments& args) {
         return Boolean::New(true);
 }
 
-static Handle<Value> GetList(const Arguments& args) {
+static Handle<Value> glist(const Arguments& args) {
 	HandleScope scope;
 	char list[XATTR_SIZE],value[XATTR_SIZE];
 	const char *filename;
@@ -138,7 +138,7 @@ static Handle<Value> get(const Arguments& args) {
 	return result;
 }
 
-static Handle<Value> SimpleList(const Arguments& args) {
+static Handle<Value> list(const Arguments& args) {
 	HandleScope scope;
 	char list[XATTR_SIZE];
 	const char *filename;
@@ -196,8 +196,8 @@ extern "C" {
 
 	void init (Handle<Object> target)
 	{
-		NODE_SET_METHOD(target, "list",  SimpleList);
-		NODE_SET_METHOD(target, "glist", GetList);
+		NODE_SET_METHOD(target, "list",  list);
+		NODE_SET_METHOD(target, "glist", glist);
 		NODE_SET_METHOD(target, "set", set);
 		NODE_SET_METHOD(target, "get", get);
 		NODE_SET_METHOD(target, "remove", remove);

--- a/src/node_xattr.cc
+++ b/src/node_xattr.cc
@@ -74,7 +74,7 @@ static Handle<Value> set(const Arguments& args) {
         return Boolean::New(true);
 }
 
-static Handle<Value> list(const Arguments& args) {
+static Handle<Value> GetList(const Arguments& args) {
 	HandleScope scope;
 	char list[XATTR_SIZE],value[XATTR_SIZE];
 	const char *filename;
@@ -94,10 +94,6 @@ static Handle<Value> list(const Arguments& args) {
 	// create obj for return
 	Handle<Object> result = Object::New();
 
-	if (listLen<1){
-		return result;
-	}
-
 	//for each of the attrs, do getxattr and add them as key/val to the obj
 	for (ns=0; ns<listLen; ns+= strlen(&list[ns])+1){
 #ifdef __APPLE__
@@ -105,19 +101,106 @@ static Handle<Value> list(const Arguments& args) {
 #else
 		  valueLen = getxattr(filename, &list[ns],value, XATTR_SIZE);
 #endif
-		//if (valueLen > 0){
+		if (valueLen > 0){
 			result->Set(String::New(&list[ns]),String::New(value, valueLen));
-		//}
+		}
 	} 
 	return result;
 }
+
+static Handle<Value> get(const Arguments& args) {
+	HandleScope scope;
+	char *attr,value[XATTR_SIZE];
+	const char *filename;
+	const char *attribute;
+
+	ssize_t valueLen;
+	int ns;
+
+	//make sure we were passed a string
+	REQ_STR_ARG(0, s1);
+	filename= ObjectToString(s1).c_str();
+	REQ_STR_ARG(1, s2);
+	attribute= ObjectToString(s2).c_str();
+
+
+	// create obj for return
+	Handle<Object> result = Object::New();
+
+	//for each of the attrs, do getxattr and add them as key/val to the obj
+#ifdef __APPLE__
+		  valueLen = getxattr(filename, attribute,value, XATTR_SIZE, 0, 0);
+#else
+		  valueLen = getxattr(filename, attribute,value, XATTR_SIZE);
+#endif
+			result->Set(String::New(attribute),String::New(value));
+
+	return result;
+}
+
+static Handle<Value> SimpleList(const Arguments& args) {
+	HandleScope scope;
+	char list[XATTR_SIZE];
+	const char *filename;
+	ssize_t listLen;
+	int ns;
+
+	//make sure we were passed a string
+	REQ_STR_ARG(0, s);
+	filename= ObjectToString(s).c_str();
+
+	//get all the extended attributes on filename
+#ifdef __APPLE__
+	listLen = listxattr(filename,list,XATTR_SIZE,0);
+#else
+	listLen = listxattr(filename,list,XATTR_SIZE);
+#endif
+	// create obj for return
+	Handle<Object> result = Object::New();
+
+	//for each of the attrs, do getxattr and add them as key/val to the obj
+	int nc=0;
+	for (ns=0; ns<listLen; ns+= strlen(&list[ns])+1){
+			nc++;
+			result->Set(nc,String::New(&list[ns]));
+	} 
+	return result;
+}
+static Handle<Value> remove(const Arguments& args) {
+	HandleScope scope;
+	ssize_t res;
+	int valLen;
+
+        REQ_ASCII_ARG(0,filename);
+        REQ_ASCII_ARG(1,attribute);
+#ifdef __APPLE__
+	res = removexattr(*filename, *attribute,0);
+#else
+	res = removexattr(*filename, *attribute);
+#endif
+        //printf("Setting file: %s, attribute: %s, value: %s, length: %d\n", *filename, *attribute, *val,val.length());
+
+
+	//Error
+	if (res == -1){
+                return ThrowException(Exception::TypeError(             \
+                        String::Concat(String::New("Error removing extended attribue: "), String::New(strerror(errno)))));
+	}
+	
+        return Boolean::New(true);
+}
+
+
 
 extern "C" {
 
 	void init (Handle<Object> target)
 	{
-		NODE_SET_METHOD(target, "list", list);
+		NODE_SET_METHOD(target, "list",  SimpleList);
+		NODE_SET_METHOD(target, "glist", GetList);
 		NODE_SET_METHOD(target, "set", set);
+		NODE_SET_METHOD(target, "get", get);
+		NODE_SET_METHOD(target, "remove", remove);
 	}
 
 	NODE_MODULE(xattr, init);

--- a/src/node_xattr.cc
+++ b/src/node_xattr.cc
@@ -133,7 +133,7 @@ static Handle<Value> get(const Arguments& args) {
 #else
 		  valueLen = getxattr(filename, attribute,value, XATTR_SIZE);
 #endif
-			result->Set(String::New(attribute),String::New(value));
+			result->Set(String::New(attribute),String::New(value,valueLen));
 
 	return result;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-var xattr = require("/home/grant/.nvm/v0.8.14/lib/node_modules/xattr/build/Release/xattr.node");
-var utils = require("/home/grant/projects/node-xattr/node-xattr/test/utils.js");
+var xattr = require("../build/Release/xattr.node");
+var utils = require("./utils");
 
 var startingRuns=false;
 var errorCount=0;

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ function runTest(runs){
 
 
 		function check() {
-			var data = xattr.list(filename);
+			var data = xattr.glist(filename);
 
 			for (var i = 0; i<4; i++){
 				if (data["user.p"+i] != vals["v" + i]){

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-var xattr = require("../build/Release/xattr.node");
-var utils = require("./utils");
+var xattr = require("/home/grant/.nvm/v0.8.14/lib/node_modules/xattr/build/Release/xattr.node");
+var utils = require("/home/grant/projects/node-xattr/node-xattr/test/utils.js");
 
 var startingRuns=false;
 var errorCount=0;
@@ -41,7 +41,7 @@ function runTest(runs){
 
 
 		function check() {
-			var data = xattr.list(filename);
+			var data = xattr.glist(filename);
 
 			for (var i = 0; i<4; i++){
 				if (data["user.p"+i] != vals["v" + i]){

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,7 +6,6 @@ var filename = "/tmp/xattr.test";
 //var filename = "/opt/solr_index/perfTest/xattr.test";
 //var filename = "/var/glusterfs/galaxy/galaxy_0/testDir/xattr.test";
 //var filename = "/var/glusterfs/polyomic/polyomic_0/testDir/xattr.test";
-var filename = "/storage/testDir/xattr.test";
 
 exports.createFile=function(index, cb){
 	if (index){


### PR DESCRIPTION
I have changed the default list to only read the names of the xattrs, not to get their data as well. 
This will result in less io overhead, and more closely matches the underlying api. 

I have left the old list as 'glist', and added 'remove' and 'get' functions.  

if you do, please pull current, fixed an important mistake
